### PR TITLE
patch: change filename prefix

### DIFF
--- a/cmd/carlet/main.go
+++ b/cmd/carlet/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"encoding/csv"
 	"fmt"
-	"github.com/anjor/carlet"
-	"github.com/urfave/cli/v2"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/anjor/carlet"
+	"github.com/urfave/cli/v2"
 )
 
 var splitCmd = &cli.Command{
@@ -25,7 +26,7 @@ var splitCmd = &cli.Command{
 			Name:     "output",
 			Aliases:  []string{"o"},
 			Required: false,
-			Usage:    "output name for car files",
+			Usage:    "output filename prefix for car files.",
 		},
 	},
 }
@@ -45,8 +46,8 @@ var splitAndCommPCmd = &cli.Command{
 		&cli.StringFlag{
 			Name:     "output",
 			Aliases:  []string{"o"},
-			Required: true,
-			Usage:    "optional output name for car files. Defaults to filename (stdin if streamed in from stdin).",
+			Required: false,
+			Usage:    "output filename prefix for car files.",
 		},
 		&cli.StringFlag{
 			Name:     "metadata",
@@ -83,7 +84,7 @@ func splitAndCommpAction(c *cli.Context) error {
 	}
 
 	w := csv.NewWriter(f)
-	err = w.Write([]string{"timestamp", "original data", "car file", "piece cid", "padded piece size"})
+	err = w.Write([]string{"timestamp", "filename prefix", "car file", "piece cid", "padded piece size"})
 	if err != nil {
 		return err
 	}
@@ -92,7 +93,7 @@ func splitAndCommpAction(c *cli.Context) error {
 		err = w.Write([]string{
 			time.Now().Format(time.RFC3339),
 			output,
-			c.CarName,
+			c.Name,
 			c.CommP.String(),
 			strconv.FormatUint(c.PaddedSize, 10),
 		})


### PR DESCRIPTION
This change is to support having simply `<piece cid>.car` filenames as the output. From the SP side we're perfectly content to just match up Piece CID from the filename and Boost, so the extra information isn't really needed (but can still be added in as a prefix if desired by the calling code) 

- renamed the variable from `output` to `namePrefix`, more descriptive
- removed the hardcoded dash separating the prefix and carfile name, so it now supports simply **pieceCid.car**, as well as an arbitrary prefix/delimiter 
- removed the `counter` suffix from the end of the final carfile filename
- removed `CarName` from `CarFile` struct and wrote the complete carfile name into `Name` instead. I'm not too sure what the separate `Name` and `CarName` were used for, but is it safe to remove that one? @anjor 

I didn't mess with the CLI flags to avoid breaking anything but I think it might be good to rename it from `output` to `prefix`, thoughts? 